### PR TITLE
fix(cinetpay): résoudre l'erreur 'notify_url must be a valid url'

### DIFF
--- a/src/app/api/payments/webhook/route.ts
+++ b/src/app/api/payments/webhook/route.ts
@@ -2,13 +2,14 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import crypto from 'crypto';
+import { config } from '@/lib/config';
 
 // Initialise un client Supabase pour le gestionnaire de route.
 // Note : Nous utilisons le SERVICE_ROLE_KEY ici pour des mises à jour sécurisées de serveur à serveur.
 // Cette clé contourne la sécurité au niveau des lignes (RLS) et doit rester secrète.
 const supabaseAdmin = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
+    config.supabase.url,
+    config.supabase.serviceRoleKey
 );
 
 // C'est le Webhook CinetPay pour recevoir les mises à jour de statut de paiement.
@@ -25,7 +26,7 @@ export async function POST(req: Request) {
     
     console.log('Webhook reçu :', JSON.stringify(eventData, null, 2));
 
-    const CINETPAY_API_SECRET_KEY = process.env.CINETPAY_API_SECRET_KEY;
+    const CINETPAY_API_SECRET_KEY = config.cinetpay.secretKey;
     const signature = req.headers.get('cpm-signature');
 
     // --- Contrôle de Sécurité : Vérifier la signature ---

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,93 @@
+// lib/config.ts
+// Configuration centralisée pour éviter les incohérences entre les variables d'environnement
+
+export const config = {
+  // URLs de l'application
+  baseUrl: process.env.NEXT_PUBLIC_BASE_URL || '',
+  
+  // CinetPay Configuration
+  cinetpay: {
+    apiKey: process.env.CINETPAY_APIKEY || '',
+    siteId: process.env.CINETPAY_SITE_ID || '',
+    secretKey: process.env.CINETPAY_SECRET_KEY || '',
+    mode: process.env.CINETPAY_MODE || 'TEST',
+    apiUrl: 'https://api-checkout.cinetpay.com/v2',
+  },
+  
+  // Supabase Configuration
+  supabase: {
+    url: process.env.NEXT_PUBLIC_SUPABASE_URL || '',
+    anonKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
+    serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY || '',
+  },
+  
+  // Business Configuration
+  business: {
+    activationCost: Number(process.env.NEXT_PUBLIC_PROPERTY_ACTIVATION_COST) || 250,
+    commissionRate: Number(process.env.NEXT_PUBLIC_CINETPAY_COMMISSION_RATE) || 2.5,
+  },
+  
+  // Email Configuration
+  email: {
+    resendApiKey: process.env.RESEND_API_KEY || '',
+    fromEmail: process.env.RESEND_FROM_EMAIL || '',
+    adminEmail: process.env.ADMIN_EMAIL || '',
+  },
+};
+
+// Validation des configurations critiques
+export function validateConfig() {
+  const errors: string[] = [];
+
+  if (!config.baseUrl) {
+    errors.push('NEXT_PUBLIC_BASE_URL est manquante');
+  }
+
+  if (!config.cinetpay.apiKey) {
+    errors.push('CINETPAY_APIKEY est manquante');
+  }
+
+  if (!config.cinetpay.siteId) {
+    errors.push('CINETPAY_SITE_ID est manquante');
+  }
+
+  if (!config.cinetpay.secretKey) {
+    errors.push('CINETPAY_SECRET_KEY est manquante');
+  }
+
+  if (!config.supabase.url) {
+    errors.push('NEXT_PUBLIC_SUPABASE_URL est manquante');
+  }
+
+  if (!config.supabase.anonKey) {
+    errors.push('NEXT_PUBLIC_SUPABASE_ANON_KEY est manquante');
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Configuration invalide: ${errors.join(', ')}`);
+  }
+}
+
+// Utilitaires pour construire les URLs
+export function buildNotifyUrl(): string {
+  return `${config.baseUrl}/api/payments/webhook`;
+}
+
+export function buildReturnUrl(path: string = '/profil/paiements'): string {
+  return `${config.baseUrl}${path}`;
+}
+
+// Validation des URLs
+export function validateUrls() {
+  const notifyUrl = buildNotifyUrl();
+  const returnUrl = buildReturnUrl();
+
+  try {
+    new URL(notifyUrl);
+    new URL(returnUrl);
+  } catch (error) {
+    throw new Error(`URLs invalides: notify_url=${notifyUrl}, return_url=${returnUrl}`);
+  }
+
+  return { notifyUrl, returnUrl };
+}


### PR DESCRIPTION
- Correction des variables d'environnement incohérentes dans /api/payments/initiate
- Remplacement de CINETPAY_API_KEY par CINETPAY_APIKEY (coherent avec .env)
- Remplacement de NEXT_PUBLIC_APP_URL par NEXT_PUBLIC_BASE_URL (définie dans .env)
- Ajout d'une configuration centralisée (src/lib/config.ts) pour éviter les incohérences
- Amélioration de la validation des URLs avant envoi à CinetPay
- Correction des variables dans le webhook (CINETPAY_SECRET_KEY)
- Refactorisation du service CinetPay pour utiliser la configuration centralisée
- Ajout de logs de debug améliorés avec masquage des clés API

Résout le problème des URLs undefined qui causaient l'erreur CinetPay